### PR TITLE
Make batch_normalization more flexible with BorrowMut

### DIFF
--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -260,6 +260,7 @@ macro_rules! curve_impl {
                     tmp.mul_assign(&g.z);
                     prod.push(tmp);
                 }
+                if prod.is_empty() { return; }
 
                 // Invert `tmp`.
                 tmp = tmp.inverse().unwrap(); // Guaranteed to be nonzero.

--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -243,7 +243,7 @@ macro_rules! curve_impl {
                 self.is_zero() || self.z == $basefield::one()
             }
 
-            fn batch_normalization(v: &mut [Self])
+            fn batch_normalization<S: ::std::borrow::BorrowMut<Self>>(v: &mut [S])
             {
                 // Montgomery’s Trick and Fast Implementation of Masked AES
                 // Genelle, Prouff and Quisquater
@@ -253,6 +253,7 @@ macro_rules! curve_impl {
                 let mut prod = Vec::with_capacity(v.len());
                 let mut tmp = $basefield::one();
                 for g in v.iter_mut()
+				          .map(|g| g.borrow_mut())
                           // Ignore normalized elements
                           .filter(|g| !g.is_normalized())
                 {
@@ -265,6 +266,7 @@ macro_rules! curve_impl {
 
                 // Second pass: iterate backwards to compute inverses
                 for (g, s) in v.iter_mut()
+                               .map(|g| g.borrow_mut())
                                // Backwards
                                .rev()
                                // Ignore normalized elements
@@ -282,6 +284,7 @@ macro_rules! curve_impl {
 
                 // Perform affine transformations
                 for g in v.iter_mut()
+                          .map(|g| g.borrow_mut())
                           .filter(|g| !g.is_normalized())
                 {
                     let mut z = g.z; // 1/z

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub trait CurveProjective:
 
     /// Normalizes a slice of projective elements so that
     /// conversion to affine is cheap.
-    fn batch_normalization(v: &mut [Self]);
+    fn batch_normalization<S: ::std::borrow::BorrowMut<Self>>(v: &mut [S]);
 
     /// Checks if the point is already "normalized" so that
     /// cheap affine conversion is possible.


### PR DESCRIPTION
I have not checked if this causes any performance regressions in existing cases, but it should enable some very minor optimizations at `batch_normalization` call sites. 