### PR TITLE
Derives n borrows

### DIFF
--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -45,9 +45,14 @@ macro_rules! curve_impl {
                 if self.is_zero() {
                     return other.is_zero();
                 }
-
                 if other.is_zero() {
                     return false;
+                }
+
+                if self.is_normalized() {
+                    if other.is_normalized() {
+                        return self.into_affine() == other.into_affine()
+                    }
                 }
 
                 // The points (X, Y, Z) and (X', Y', Z')

--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -239,7 +239,8 @@ macro_rules! curve_impl {
                 self.is_zero() || self.z == $basefield::one()
             }
 
-            fn batch_normalization(v: &mut [Self]) {
+            fn batch_normalization<S: ::std::borrow::BorrowMut<Self>>(v: &mut [S])
+            {
                 // Montgomery’s Trick and Fast Implementation of Masked AES
                 // Genelle, Prouff and Quisquater
                 // Section 3.2
@@ -247,8 +248,8 @@ macro_rules! curve_impl {
                 // First pass: compute [a, ab, abc, ...]
                 let mut prod = Vec::with_capacity(v.len());
                 let mut tmp = $basefield::one();
-                for g in v
-                    .iter_mut()
+                for g in v.iter_mut()
+	            .map(|g| g.borrow_mut())
                     // Ignore normalized elements
                     .filter(|g| !g.is_normalized())
                 {
@@ -260,17 +261,15 @@ macro_rules! curve_impl {
                 tmp = tmp.inverse().unwrap(); // Guaranteed to be nonzero.
 
                 // Second pass: iterate backwards to compute inverses
-                for (g, s) in v
-                    .iter_mut()
+                for (g, s) in v.iter_mut()
+                    .map(|g| g.borrow_mut())
                     // Backwards
                     .rev()
                     // Ignore normalized elements
                     .filter(|g| !g.is_normalized())
                     // Backwards, skip last element, fill in one for last term.
                     .zip(
-                        prod.into_iter()
-                            .rev()
-                            .skip(1)
+                        prod.into_iter().rev().skip(1)
                             .chain(Some($basefield::one())),
                     )
                 {
@@ -283,7 +282,10 @@ macro_rules! curve_impl {
                 }
 
                 // Perform affine transformations
-                for g in v.iter_mut().filter(|g| !g.is_normalized()) {
+                for g in v.iter_mut()
+                    .map(|g| g.borrow_mut())
+                    .filter(|g| !g.is_normalized())
+                {
                     let mut z = g.z; // 1/z
                     z.square(); // 1/z^2
                     g.x.mul_assign(&z); // x/z^2

--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -623,6 +623,18 @@ macro_rules! curve_impl {
 
 macro_rules! encoded_point_delegations {
 	($t:ident) => {
+
+	    impl AsRef<[u8]> for $t {
+	        fn as_ref(&self) -> &[u8] {
+	            &self.0
+	        }
+	    }
+	    impl AsMut<[u8]> for $t {
+	        fn as_mut(&mut self) -> &mut [u8] {
+	            &mut self.0
+	        }
+	    }
+
 	    impl PartialEq for $t {
 	        fn eq(&self, other: &$t) -> bool {
 				PartialEq::eq(&self.0[..], &other.0[..]) 
@@ -671,18 +683,6 @@ pub mod g1 {
 
     #[derive(Copy, Clone)]
     pub struct G1Uncompressed([u8; 96]);
-
-    impl AsRef<[u8]> for G1Uncompressed {
-        fn as_ref(&self) -> &[u8] {
-            &self.0
-        }
-    }
-
-    impl AsMut<[u8]> for G1Uncompressed {
-        fn as_mut(&mut self) -> &mut [u8] {
-            &mut self.0
-        }
-    }
 
     encoded_point_delegations!(G1Uncompressed);
 
@@ -783,18 +783,6 @@ pub mod g1 {
 
     #[derive(Copy, Clone)]
     pub struct G1Compressed([u8; 48]);
-
-    impl AsRef<[u8]> for G1Compressed {
-        fn as_ref(&self) -> &[u8] {
-            &self.0
-        }
-    }
-
-    impl AsMut<[u8]> for G1Compressed {
-        fn as_mut(&mut self) -> &mut [u8] {
-            &mut self.0
-        }
-    }
 
     encoded_point_delegations!(G1Compressed);
 
@@ -1345,18 +1333,6 @@ pub mod g2 {
     #[derive(Copy, Clone)]
     pub struct G2Uncompressed([u8; 192]);
 
-    impl AsRef<[u8]> for G2Uncompressed {
-        fn as_ref(&self) -> &[u8] {
-            &self.0
-        }
-    }
-
-    impl AsMut<[u8]> for G2Uncompressed {
-        fn as_mut(&mut self) -> &mut [u8] {
-            &mut self.0
-        }
-    }
-
     encoded_point_delegations!(G2Uncompressed);
 
     impl fmt::Debug for G2Uncompressed {
@@ -1472,18 +1448,6 @@ pub mod g2 {
 
     #[derive(Copy, Clone)]
     pub struct G2Compressed([u8; 96]);
-
-    impl AsRef<[u8]> for G2Compressed {
-        fn as_ref(&self) -> &[u8] {
-            &self.0
-        }
-    }
-
-    impl AsMut<[u8]> for G2Compressed {
-        fn as_mut(&mut self) -> &mut [u8] {
-            &mut self.0
-        }
-    }
 
     encoded_point_delegations!(G2Compressed);
 

--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -621,6 +621,33 @@ macro_rules! curve_impl {
     };
 }
 
+macro_rules! encoded_point_delegations {
+	($t:ident) => {
+	    impl PartialEq for $t {
+	        fn eq(&self, other: &$t) -> bool {
+				PartialEq::eq(&self.0[..], &other.0[..]) 
+			}
+        }
+	    impl Eq for $t { }
+        impl PartialOrd for $t {
+			fn partial_cmp(&self, other: &$t) -> Option<::std::cmp::Ordering> {
+				PartialOrd::partial_cmp(&self.0[..], &other.0[..])
+			}
+		}
+        impl Ord for $t {
+	        fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+				Ord::cmp(&self.0[..], &other.0[..])
+	        }
+	    }
+
+		impl ::std::hash::Hash for $t {
+	        fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
+	        	self.0[..].hash(state);
+	        }
+		}
+	}
+} // encoded_point_delegations
+
 pub mod g1 {
     use super::super::{Bls12, Fq, Fq12, FqRepr, Fr, FrRepr};
     use super::g2::G2Affine;
@@ -656,6 +683,8 @@ pub mod g1 {
             &mut self.0
         }
     }
+
+    encoded_point_delegations!(G1Uncompressed);
 
     impl fmt::Debug for G1Uncompressed {
         fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -766,6 +795,8 @@ pub mod g1 {
             &mut self.0
         }
     }
+
+    encoded_point_delegations!(G1Compressed);
 
     impl fmt::Debug for G1Compressed {
         fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -1326,6 +1357,8 @@ pub mod g2 {
         }
     }
 
+    encoded_point_delegations!(G2Uncompressed);
+
     impl fmt::Debug for G2Uncompressed {
         fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
             self.0[..].fmt(formatter)
@@ -1451,6 +1484,8 @@ pub mod g2 {
             &mut self.0
         }
     }
+
+    encoded_point_delegations!(G2Compressed);
 
     impl fmt::Debug for G2Compressed {
         fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {


### PR DESCRIPTION
Adds some basic traits to encoded points and makes batch_normalization slightly easier to use.  

Also adds one more shirt circuit check for affine point equality, but maybe this does not help much. 