### PR TITLE
Make tests run with 'cargo test', currently failing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,6 @@
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]
 
-#[cfg(test)]
-#[macro_use]
-extern crate std;
-
-#[cfg(test)]
-pub mod tests;
-
 use core::ops::Mul;
 use ff::PrimeField;
 use group::{

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,0 @@
-pub mod engine;
-pub mod field;
-pub mod repr;

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -4,9 +4,10 @@ use group::{prime::PrimeCurveAffine, Curve, Group};
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
-use crate::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine};
+use pairing::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine};
 
-pub fn engine_tests<E: MultiMillerLoop>() {
+#[test]
+fn engine_tests<E: MultiMillerLoop>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,

--- a/tests/field.rs
+++ b/tests/field.rs
@@ -2,6 +2,7 @@ use ff::{Field, PrimeField};
 use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
+#[test]
 pub fn random_sqrt_tests<F: Field>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
@@ -34,6 +35,7 @@ pub fn random_sqrt_tests<F: Field>() {
     }
 }
 
+#[test]
 pub fn random_field_tests<F: Field>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
@@ -73,7 +75,8 @@ pub fn random_field_tests<F: Field>() {
     }
 }
 
-pub fn from_str_tests<F: PrimeField>() {
+#[test]
+fn from_str_tests<F: PrimeField>() {
     {
         let a = "84395729384759238745923745892374598234705297301958723458712394587103249587213984572934750213947582345792304758273458972349582734958273495872304598234";
         let b = "38495729084572938457298347502349857029384609283450692834058293405982304598230458230495820394850293845098234059823049582309485203948502938452093482039";

--- a/tests/repr.rs
+++ b/tests/repr.rs
@@ -2,6 +2,7 @@ use ff::PrimeField;
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
+#[test]
 pub fn random_repr_tests<P: PrimeField>() {
     random_encoding_tests::<P>();
 }


### PR DESCRIPTION
On pairing#main, the tests are not automatically run by `cargo test`, this enables them even though some are failing because the test functions are not being called with a trait impl defined, just the trait.