### PR TITLE
feat: add additional trait bounds for Engine

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use group::{
 /// An "engine" is a collection of types (fields, elliptic curve groups, etc.)
 /// with well-defined relationships. In particular, the G1/G2 curve groups are
 /// of prime order `r`, and are equipped with a bilinear pairing function.
-pub trait Engine: Sized + 'static + Clone {
+pub trait Engine: Sized + 'static + Clone + Sync + Send + core::fmt::Debug {
     /// This is the scalar field of the engine's groups.
     type Fr: PrimeField;
 


### PR DESCRIPTION
These bounds should be always implemented, as the Engine is expected to
be just a type container